### PR TITLE
Add distribution metric example

### DIFF
--- a/dofns/generate_sessions_dofn.py
+++ b/dofns/generate_sessions_dofn.py
@@ -81,7 +81,7 @@ class GenerateSessionsDoFn(beam.DoFn):
         end_time = last_event.timestamp
 
         journey_length_seconds = (end_time - start_time).total_seconds()
-        distance = events_count  # Just an example, this could be actual distance
+        distance = last_event.meter_reading  # Just an example, this could be actual distance
         session_speed = distance / journey_length_seconds
         self._distribution.update(session_speed)
 


### PR DESCRIPTION
Add an example of a distribution metric, calculating "session speed" (distance is just the number of events in this example), to produce a distribution metric that is meant to be a "business level"-SLI.